### PR TITLE
Fix: Add bicycle_road tag to classification (issue #150)

### DIFF
--- a/R/osmactive.R
+++ b/R/osmactive.R
@@ -7,6 +7,7 @@ et_active = function() {
     "oneway",
     "maxspeed",
     "bicycle",
+    "bicycle_road",
     "cycleway",
     "cycleway:left",
     "cycleway:right",
@@ -358,6 +359,7 @@ classify_cycle_infrastructure_scotland = function(
     # If highway == cycleway|pedestrian|path, detailed_segregation can be defined in most cases...
     dplyr::mutate(
       detailed_segregation = dplyr::case_when(
+        bicycle_road == "yes" ~ "Level track",
         highway == "cycleway" ~ "Level track",
         highway %in%
           c("footway", "path", "Pedestrian") &


### PR DESCRIPTION
## Summary

This PR fixes issue #150 by adding support for the `bicycle_road` OSM tag.

## Changes

1. Added `bicycle_road` to `et_active()` - ensures the tag is retrieved from OSM data
2. Added classification logic - roads with `bicycle_road=yes` are now classified as `Level track`

## Why

The `bicycle_road` tag is commonly used in Germany (e.g., Munich) to designate bicycle boulevards. Previously, these roads were not being classified in osmactive, causing them to be missed in analysis.

## Testing

Run osmactive on German cities (e.g., Munich) and verify that roads with `bicycle_road=yes` are now included.

---

Fixes #150
